### PR TITLE
Fixed #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .gradle/
+.idea/
 bin/
 build/
+out/
 run/
 .classpath
 .project
 reset.bat
+*.iml

--- a/src/main/java/yuudaari/soulus/Soulus.java
+++ b/src/main/java/yuudaari/soulus/Soulus.java
@@ -1,6 +1,7 @@
 package yuudaari.soulus;
 
 import yuudaari.soulus.client.ModRenderers;
+import yuudaari.soulus.common.compat.crafttweaker.ZenComposer;
 import yuudaari.soulus.common.network.SoulsPacketHandler;
 import yuudaari.soulus.common.network.packet.client.SendConfig;
 import yuudaari.soulus.common.util.Logger;
@@ -39,7 +40,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.registries.IForgeRegistry;
 
-@Mod(modid = Soulus.MODID, name = Soulus.NAME, version = "@VERSION@", acceptedMinecraftVersions = "[1.12.2]")
+@Mod(modid = Soulus.MODID, name = Soulus.NAME, version = "@VERSION@", acceptedMinecraftVersions = "[1.12.2]", dependencies = "after:crafttweaker")
 @Mod.EventBusSubscriber
 public class Soulus {
 
@@ -167,6 +168,10 @@ public class Soulus {
 		SoulsPacketHandler.register();
 		if (Loader.isModLoaded("exnihilocreatio")) {
 			ExNihiloCreatioRecipes.init();
+		}
+
+		if (Loader.isModLoaded("crafttweaker")) {
+			ZenComposer.apply();
 		}
 	}
 


### PR DESCRIPTION
This change delays the processing of all Soulus specific recipe additions and removals until after CraftTweaker (CT) has processed its recipes in its PostInit phase.

A soft, order-only dependency on crafttweaker was added to the mod's `@Mod` annotation to ensure that if CT is available, Soulus will be loaded after it, therefore processing its PostInit event after CT.

In Soulus' PostInit handler, a call to the `ZenComposer::apply()` is made to apply aggregated `IAction` implementations in the proper order.

Creation of the recipes, specifically the resolution of oredict ingredients has been moved to the respective `IAction#apply()` methods to ensure that mods and CT scripts have ample time to manipulate the oredict entries before resolution.

Tested using the script provided in #37 :
```
import mods.soulus.Composer;
recipes.remove(<minecraft:stone:1>);
Composer.addShaped("mytest", <minecraft:stone:1>, 512, [ [<minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, null, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>] ]);
```

The granite recipe added after the removal is not removed.

Also tested in reverse:
```
import mods.soulus.Composer;
Composer.addShaped("mytest", <minecraft:stone:1>, 512, [ [<minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, null, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>] ]);
recipes.remove(<minecraft:stone:1>);
```

Again, the soulus specific granite recipe added is not removed because the removals are processed before the additions. This behavior conforms to CT behavior and the behavior of most mods that implement CT, as well as expected and accepted behavior by pack developers.

Three new entries were also added to the `.gitignore` to prevent project contamination by Intellij users.