### PR TITLE
Fix murky orb and full soulbook advancements

### DIFF
--- a/src/main/resources/assets/soulus/advancements/orb_murky.json
+++ b/src/main/resources/assets/soulus/advancements/orb_murky.json
@@ -19,7 +19,7 @@
 				"items": [
 					{
 						"item": "soulus:orb_murky",
-						"nbt": "{\"essence_quantity\":128}"
+						"nbt": "{\"essence_quantity\":32}"
 					}
 				]
 			}

--- a/src/main/resources/assets/soulus/advancements/soulbook_fill.json
+++ b/src/main/resources/assets/soulus/advancements/soulbook_fill.json
@@ -19,7 +19,7 @@
 				"items": [
 					{
 						"item": "soulus:soulbook",
-						"nbt": "{\"essence_quantity\":16}"
+						"nbt": "{\"essence_quantity\":32}"
 					}
 				]
 			}


### PR DESCRIPTION
Seems the maximum essence contained in these items had changed since the advancements were created?